### PR TITLE
Replace TortoiseMerge with WinMerge

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -22,7 +22,7 @@ cinst pulumi -y
 cinst azure-cli -y
 cinst mingw -y
 cinst ruby -y
-cinst tortoisemerge kdiff3 -y
+cinst winmerge kdiff3 -y
 
 refreshenv
 


### PR DESCRIPTION
TortoiseMerge Chocolatey package appears to be broken: https://community.chocolatey.org/packages/tortoisemerge

```
ERROR: The remote file either doesn't exist, is unauthorized, or is forbidden for url 'http://aarnet.dl.sourceforge.net/project/tortoisesvn/Tools/1.6.7/TortoiseDiff-1.6.7.zip'. Exception calling "GetResponse" with "0" argument(s): "The remote name could not be resolved: 'aarnet.dl.sourceforge.net'"
The install of tortoisemerge was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\tortoisemerge\tools\chocolateyInstall.ps1'.
 See log for details.
```